### PR TITLE
Require a trailing comma in multiline object literals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,10 +24,11 @@ module.exports = {
 
     // possible errors
     'array-callback-return': 'error',
+    'comma-dangle': ['error', 'always-multiline'],
     'consistent-return': 'error',
     'default-case': 'error',
     'dot-notation': 'error',
-    eqeqeq: 'error',
+    'eqeqeq': 'error',
     'for-direction': 'error',
     'no-alert': 'error',
     'no-caller': 'error',

--- a/bugs.js
+++ b/bugs.js
@@ -41,20 +41,20 @@ const fetchBugs = async (listFile = 'data/list.csv', bugzillaKey, githubKey, min
     const fileStream = fs.createReadStream(listFile);
     const rl = readline.createInterface({
         input: fileStream,
-        crlfDelay: Infinity
+        crlfDelay: Infinity,
     });
 
     for await (const line of rl) {
         const website = line.split(',')[1];
         const {
             bugzillaResult,
-            bugzillaMobileResult
+            bugzillaMobileResult,
         } = await getBugzilla(website, bugzillaKey, minDate, maxDate);
         bugzilla.push(bugzillaResult);
         bugzillaMobile.push(bugzillaMobileResult);
         const {
             duplicatesResult,
-            duplicatesMobileResult
+            duplicatesMobileResult,
         } = await getDuplicates(website, bugzillaKey, githubKey, minDate, maxDate);
         duplicates.push(duplicatesResult);
         duplicatesMobile.push(duplicatesMobileResult);
@@ -62,7 +62,7 @@ const fetchBugs = async (listFile = 'data/list.csv', bugzillaKey, githubKey, min
             webcompatResult,
             criticalsResult,
             webcompatMobileResult,
-            criticalsMobileResult
+            criticalsMobileResult,
         } = await getWebcompat(website, githubKey, minDate, maxDate);
         webcompat.push(webcompatResult);
         criticals.push(criticalsResult);
@@ -104,7 +104,7 @@ function getBugzillaProducts() {
         "Firefox",
         "Firefox for Android",
         "GeckoView",
-        "Web Compatibility"
+        "Web Compatibility",
     ];
     return `&product=${products.map(i => encodeURIComponent(i)).join("&product=")}`;
 }
@@ -117,7 +117,7 @@ function getBugzillaStatuses() {
         "UNCONFIRMED",
         "NEW",
         "ASSIGNED",
-        "REOPENED"
+        "REOPENED",
     ];
     return `&bug_status=${statuses.map(i => encodeURIComponent(i)).join("&bug_status=")}`;
 }
@@ -129,7 +129,7 @@ function getBugzillaPriorities() {
     const priorities = [
         "P1",
         "P2",
-        "P3"
+        "P3",
     ];
     return `&priority=${priorities.map(i => encodeURIComponent(i)).join("&priority=")}`;
 }
@@ -225,8 +225,8 @@ const getOctokitInstance = (function() {
                     onAbuseLimit: (retryAfter, options) => {
                         // Don't retry, only log an error.
                         console.error(`Abuse detected for request to ${options.url}!`)
-                    }
-                }
+                    },
+                },
             }));
         }
         return singletons.get(githubKey);
@@ -460,10 +460,10 @@ const getDuplicates = async (website, bugzillaKey, githubKey, minDate, maxDate) 
     const bzMobileLink = `https://bugzilla.mozilla.org/buglist.cgi?o1=anyexact&v1=${mobileParam}&f1=bug_id`;
     return {
         duplicatesResult: dupedGhIds.size ? `=HYPERLINK("${bzLink}"; ${dupedGhIds.size})`: 0,
-        duplicatesMobileResult: dupedMobileGhIds.size ? `=HYPERLINK("${bzMobileLink}"; ${dupedMobileGhIds.size})` : 0
+        duplicatesMobileResult: dupedMobileGhIds.size ? `=HYPERLINK("${bzMobileLink}"; ${dupedMobileGhIds.size})` : 0,
     };
 }
 
 module.exports = {
-    fetchBugs
+    fetchBugs,
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "GOOGLE_APPLICATION_CREDENTIALS='credentials.json' node index.js",
     "lint": "eslint *.js",
+    "lint-fix": "run-p 'lint -- --fix'",
     "test": "run-p lint"
   },
   "repository": {

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -5,7 +5,7 @@ async function createSpreadsheet(sheets, title, maxDate) {
     const resource = {
         properties: {
             title,
-        }
+        },
     }
     const { data } = await sheets.spreadsheets.create({ resource });
     const spreadsheetId = data.spreadsheetId;
@@ -22,9 +22,9 @@ async function createSpreadsheet(sheets, title, maxDate) {
                         sheetId,
                         title: sheetTitle,
                     },
-                    "fields": "title"
+                    "fields": "title",
                 },
-            }]
+            }],
         },
     });
 
@@ -58,7 +58,7 @@ async function updateSummary(sheets, spreadsheetId, date) {
         requests.push({
             "insertRange": {
                 range,
-                "shiftDimension": 'ROWS'
+                "shiftDimension": 'ROWS',
             },
         });
         const batchUpdateRequest = { requests };
@@ -81,7 +81,7 @@ async function updateSummary(sheets, spreadsheetId, date) {
             `='${title}'!$L$1`,
             `='${title}'!$M$1`,
             `='${title}'!$O$1`,
-            `='${title}'!$P$1`
+            `='${title}'!$P$1`,
         ];
         result = await sheets.spreadsheets.values.update({
             spreadsheetId,
@@ -224,12 +224,12 @@ async function findOrCreateSheet(sheets, spreadsheetId, maxDate) {
                 requests: [{
                     "updateCells": {
                         "range": {
-                            sheetId
+                            sheetId,
                         },
-                        "fields": "userEnteredValue"
-                    }
-                }]
-            }
+                        "fields": "userEnteredValue",
+                    },
+                }],
+            },
         });
         console.log(`Found and cleared sheet with ID ${sheetId}`);
         break;
@@ -242,18 +242,18 @@ async function findOrCreateSheet(sheets, spreadsheetId, maxDate) {
                 requests: [{
                     "addSheet": {
                         "properties": {
-                            title
-                        }
-                    }
-                }]
-            }
+                            title,
+                        },
+                    },
+                }],
+            },
         });
         sheetId = result.data.replies[0].addSheet.properties.sheetId;
         console.log(`Added sheet with ID ${sheetId}`);
     }
     return {
         sheetId,
-        title
+        title,
     }
 }
 
@@ -269,7 +269,7 @@ async function addStaticData(sheets, spreadsheetId, listSize, listFile = 'data/l
         "startRowIndex": 0,
         "endRowIndex": 1,
         "startColumnIndex": 0,
-        "endColumnIndex": 2
+        "endColumnIndex": 2,
     };
     const headers = ['Rank', 'Website', 'bugzilla', 'bugzilla-M', 'webcompat.com',
         'webcompat-M', 'criticals', 'criticals-M', 'duplicates',
@@ -280,14 +280,14 @@ async function addStaticData(sheets, spreadsheetId, listSize, listFile = 'data/l
     requests.push({
         "insertRange": {
             range,
-            "shiftDimension": 'ROWS'
+            "shiftDimension": 'ROWS',
         },
     });
     // Insert header row.
     requests.push({
         "insertRange": {
             range,
-            "shiftDimension": 'ROWS'
+            "shiftDimension": 'ROWS',
         },
     });
 
@@ -316,7 +316,7 @@ async function addStaticData(sheets, spreadsheetId, listSize, listFile = 'data/l
         `=SUM(M3:M${listSize + 2})`,
         "",
         `=SUM(O3:O${listSize + 2})`,
-        `=SUM(P3:P${listSize + 2})`
+        `=SUM(P3:P${listSize + 2})`,
     ];
     result = await sheets.spreadsheets.values.update({
         spreadsheetId,
@@ -427,7 +427,7 @@ async function addStaticData(sheets, spreadsheetId, listSize, listFile = 'data/l
     const fileStream = fs.createReadStream(listFile);
     const rl = readline.createInterface({
         input: fileStream,
-        crlfDelay: Infinity
+        crlfDelay: Infinity,
     });
 
     const ranks = [];

--- a/tranco.js
+++ b/tranco.js
@@ -30,7 +30,7 @@ const removeIgnoredDomains = function (listFile) {
                 countMatches: true,
                 files: listFile,
                 from: DOMAINS_REGEXP_CACHE,
-                to: ''
+                to: '',
             }).then(results => {
                 if (!results[0].hasChanged) {
                     console.warn('Warning: config.ignoredDomains set, but the list was not modified.');
@@ -136,5 +136,5 @@ function parseDate(date) {
 }
 
 module.exports = {
-    fetchList
+    fetchList,
 }


### PR DESCRIPTION
This fixes the original request behind #74, but it doesn't go as far as what is required there. Fixing linting errors can be done via `npm run lint-fix`, which is how most of this patch was created.