### PR TITLE
Fixes #100 - Add a --resume option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ and including Saturday May 25 2018:
 npm start 2019-05-23
 ```
 
+A `--resume` option also exists, to continue collecting weekly results until the present date, rather than just a single weekly result:
+
+```
+npm start 2019-05-23 -- --resume
+```
+
 Code of Conduct
 ===============
 

--- a/helpers.js
+++ b/helpers.js
@@ -153,6 +153,87 @@ function filterWebCompatSeeAlso(bug) {
     return !seeAlsoArray.some(url => webCompatRegexp.test(url));
 }
 
+/**
+ * Return the End of the week the specified date belongs to.
+ * @param {Date} date the date for which to
+ * @returns the date of the end of the week
+ */
+function getEOW(date) {
+    const param = new Date(date);
+    param.setDate(param.getDate() - param.getDay() + 7);
+    return new Date(param - 1);
+}
+
+/**
+ * Return the list of query dates for a given inputDate
+ * @param {Date} inputDate the date to start with.
+ * @returns an Array with all dates to gather bugs for
+ */
+function getQueryDates(inputDate) {
+    const queryDates = [];
+    if (inputDate) {
+        // We want to consider open bugs only until the end of the given week.
+        const parsed = new Date(inputDate);
+        const today = new Date();
+        if (isNaN(parsed)) {
+            throw new Error("Wrong maxDate format: use yyyy-mm-dd");
+        }
+
+        if (!inputDate.includes("-")) {
+            // An entire year is specified.
+            for (let i = 0; i < 52; i++) {
+                queryDates.push(getEOW(parsed));
+                parsed.setDate(parsed.getDate() + 7);
+                if (getEOW(parsed) > today) {
+                    // Stop if we get into future dates (the Tranco list won't
+                    // have anything useful for us).
+                    break;
+                }
+            }
+        } else if (inputDate.indexOf("-") === inputDate.lastIndexOf("-")) {
+            // An entire month is specified.
+            const month = getEOW(parsed).getMonth();
+            for (let i = 0; i < 5; i++) {
+                queryDates.push(getEOW(parsed));
+                parsed.setDate(parsed.getDate() + 7);
+                if (getEOW(parsed).getMonth() !== month || getEOW(parsed) > today) {
+                    // Stop if the fifth consecutive Sunday falls into the next
+                    // month, or we get into future dates.
+                    break;
+                }
+            }
+        } else {
+            // A single date is specified.
+            queryDates.push(getEOW(parsed));
+        }
+    } else {
+        queryDates.push(inputDate);
+    }
+
+    return queryDates;
+}
+
+/**
+ * Return the list of query dates until the present, starting
+ * at the specified date.
+ * @param {Date} inputDate the date to resume with
+ * @returns an Array with all dates to gather bugs for
+ */
+function resumeQueryDates(inputDate) {
+    const queryDates = [];
+    const parsed = new Date(inputDate);
+    const today = new Date();
+    if (isNaN(parsed)) {
+        throw new Error("Wrong maxDate format: use yyyy-mm-dd");
+    }
+    while(getEOW(parsed) < today) {
+        queryDates.push(getEOW(parsed));
+        parsed.setDate(parsed.getDate() + 7);
+    }
+
+    return queryDates;
+}
+
 module.exports = {
     bugzillaRetry,
     formatDateForAPIQueries,
@@ -162,8 +243,11 @@ module.exports = {
     getBugzillaProducts,
     getBugzillaStatuses,
     getBzLink,
+    getEOW,
+    getQueryDates,
     filterWebCompatSeeAlso,
     isMobile,
     isDesktop,
     isNotQA,
+    resumeQueryDates,
 }

--- a/index.js
+++ b/index.js
@@ -1,90 +1,10 @@
 const { google } = require('googleapis');
-const tranco = require('./tranco');
-const spreadsheet = require('./spreadsheet');
 const bugs = require('./bugs');
+const helpers = require('./helpers');
+const spreadsheet = require('./spreadsheet');
+const tranco = require('./tranco');
 
 const argv = process.argv.slice(2);
-
-/**
- * Return the End of the week the specified date belongs to.
- * @param {Date} date the date for which to
- * @returns the date of the end of the week
- */
-function getEOW(date) {
-    const param = new Date(date);
-    param.setDate(param.getDate() - param.getDay() + 7);
-    return new Date(param - 1);
-}
-
-/**
- * Return the list of query dates for a given inputDate
- * @param {Date} inputDate the date to start with.
- * @returns an Array with all dates to gather bugs for
- */
-function getQueryDates(inputDate) {
-    const queryDates = [];
-    if (inputDate) {
-        // We want to consider open bugs only until the end of the given week.
-        const parsed = new Date(inputDate);
-        const today = new Date();
-        if (isNaN(parsed)) {
-            throw new Error("Wrong maxDate format: use yyyy-mm-dd");
-        }
-
-        if (!inputDate.includes("-")) {
-            // An entire year is specified.
-            for (let i = 0; i < 52; i++) {
-                queryDates.push(getEOW(parsed));
-                parsed.setDate(parsed.getDate() + 7);
-                if (getEOW(parsed) > today) {
-                    // Stop if we get into future dates (the Tranco list won't
-                    // have anything useful for us).
-                    break;
-                }
-            }
-        } else if (inputDate.indexOf("-") === inputDate.lastIndexOf("-")) {
-            // An entire month is specified.
-            const month = getEOW(parsed).getMonth();
-            for (let i = 0; i < 5; i++) {
-                queryDates.push(getEOW(parsed));
-                parsed.setDate(parsed.getDate() + 7);
-                if (getEOW(parsed).getMonth() !== month || getEOW(parsed) > today) {
-                    // Stop if the fifth consecutive Sunday falls into the next
-                    // month, or we get into future dates.
-                    break;
-                }
-            }
-        } else {
-            // A single date is specified.
-            queryDates.push(getEOW(parsed));
-        }
-    } else {
-        queryDates.push(inputDate);
-    }
-
-    return queryDates;
-}
-
-/**
- * Return the list of query dates until the present, starting
- * at the specified date.
- * @param {Date} inputDate the date to resume with
- * @returns an Array with all dates to gather bugs for
- */
-function resumeQueryDates(inputDate) {
-    const queryDates = [];
-    const parsed = new Date(inputDate);
-    const today = new Date();
-    if (isNaN(parsed)) {
-        throw new Error("Wrong maxDate format: use yyyy-mm-dd");
-    }
-    while(getEOW(parsed) < today) {
-        queryDates.push(getEOW(parsed));
-        parsed.setDate(parsed.getDate() + 7);
-    }
-
-    return queryDates;
-}
 
 const main = async () => {
     const config = require('./config.json');
@@ -105,9 +25,9 @@ const main = async () => {
 
     const inputDate = argv[0] || maxDate;
     if (argv.includes("--resume")) {
-        queryDates = resumeQueryDates(inputDate);
+        queryDates = helpers.resumeQueryDates(inputDate);
     } else {
-        queryDates = getQueryDates(inputDate);
+        queryDates = helpers.getQueryDates(inputDate);
     }
 
     for (const date of queryDates) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const tranco = require('./tranco');
 const spreadsheet = require('./spreadsheet');
 const bugs = require('./bugs');
 
+const argv = process.argv.slice(2);
+
 /**
  * Return the End of the week the specified date belongs to.
  * @param {Date} date the date for which to
@@ -31,7 +33,7 @@ const main = async () => {
         throw new Error("Wrong minDate format: use yyyy-mm-dd");
     }
 
-    const inputDate = process.argv[2] || maxDate;
+    const inputDate = process.argv[0] || maxDate;
     if (inputDate) {
         // We want to consider open bugs only until the end of the given week.
         const parsed = new Date(inputDate);


### PR DESCRIPTION
This allows you to pass in a given week in the past, and have it run until the present. Before this, you would have to go month to month.