### PR TITLE
Issue #75 - Add support for cloning of docs and copying of sheets

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,5 @@
 const config = require('./config.json');
 const fetch = require('node-fetch');
-const fs = require('fs');
 const retry = require('promise-fn-retry');
 const util = require('util');
 
@@ -235,18 +234,6 @@ function resumeQueryDates(inputDate) {
     return queryDates;
 }
 
-/**
- * Update config.json's spreadsheetId with the passed in `id`.
- * @param {String} id
- * @returns the new spreadsheetId from config.json
- */
-function updateConfigId(id) {
-    config.spreadsheetId = id;
-    fs.writeFileSync('config.json', JSON.stringify(config, null, 2));
-    const updatedConfig = fs.readFileSync('config.json');
-    return JSON.parse(updatedConfig).spreadsheetId;
-}
-
 module.exports = {
     bugzillaRetry,
     formatDateForAPIQueries,
@@ -263,5 +250,4 @@ module.exports = {
     isDesktop,
     isNotQA,
     resumeQueryDates,
-    updateConfigId,
 }

--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,6 @@
 const config = require('./config.json');
 const fetch = require('node-fetch');
+const fs = require('fs');
 const retry = require('promise-fn-retry');
 const util = require('util');
 
@@ -234,6 +235,18 @@ function resumeQueryDates(inputDate) {
     return queryDates;
 }
 
+/**
+ * Update config.json's spreadsheetId with the passed in `id`.
+ * @param {String} id
+ * @returns the new spreadsheetId from config.json
+ */
+function updateConfigId(id) {
+    config.spreadsheetId = id;
+    fs.writeFileSync('config.json', JSON.stringify(config, null, 2));
+    const updatedConfig = fs.readFileSync('config.json');
+    return JSON.parse(updatedConfig).spreadsheetId;
+}
+
 module.exports = {
     bugzillaRetry,
     formatDateForAPIQueries,
@@ -250,4 +263,5 @@ module.exports = {
     isDesktop,
     isNotQA,
     resumeQueryDates,
+    updateConfigId,
 }

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ const main = async () => {
     const writers = config.writers || ['user@example.com'];
     const maxDate = config.maxDate || undefined;
     const minDate = config.minDate || "2018";
-    let configId = config.spreadsheetId;
-    let id = configId;
+    let originalId = config.spreadsheetId;
+    let cloneId;
     let queryDates = [];
 
     const parsedMinDate = new Date(minDate);
@@ -45,24 +45,23 @@ const main = async () => {
         const drive = google.drive({ version: 'v3', auth })
 
         const docTitle = 'Top Site Compatibility Index';
-        if (!id) {
-            id = await spreadsheet.createSpreadsheet(sheets, docTitle, date);
-            configId = helpers.updateConfigId(id);
+        if (!originalId) {
+            originalId = await spreadsheet.createSpreadsheet(sheets, docTitle, date);
         }
         // Create a clone of the document here so we can operate on that
         // and only copy over the completed sheet.
-        id = await spreadsheet.cloneDocument(drive, id);
-        const { sheetId, title } = await spreadsheet.findOrCreateSheet(sheets, id, date);
-        await spreadsheet.addStaticData(sheets, id, LIST_SIZE, LIST_FILE, sheetId, title);
-        await spreadsheet.addBugData(sheets, id, bugTable, title);
-        await spreadsheet.copySheetToOriginal(sheets, id, configId);
+        cloneId = await spreadsheet.cloneDocument(drive, originalId);
+        const { sheetId, title } = await spreadsheet.findOrCreateSheet(sheets, cloneId, date);
+        await spreadsheet.addStaticData(sheets, cloneId, LIST_SIZE, LIST_FILE, sheetId, title);
+        await spreadsheet.addBugData(sheets, cloneId, bugTable, title);
+        await spreadsheet.copySheetToOriginal(sheets, cloneId, originalId);
+        await spreadsheet.updateSummary(sheets, originalId, date);
         // delete the clone, because we don't need it anymore.
-        await drive.files.delete({fileId: id});
-        await spreadsheet.updateSummary(sheets, configId, date);
+        await drive.files.delete({fileId: cloneId});
 
         for (const writer of writers) {
-            await spreadsheet.shareSheet(drive, configId, writer);
-            console.log(`► https://docs.google.com/spreadsheets/d/${configId}/edit`)
+            await spreadsheet.shareSheet(drive, originalId, writer);
+            console.log(`► https://docs.google.com/spreadsheets/d/${originalId}/edit`)
         }
     }
 }


### PR DESCRIPTION
The way this PR is intended to work is the following:

Before fetching bug data for a given week, clone into a new document.
Fetch all bug data.
Copy the sheet into the original document.
Delete the cloned document.

The way this works assumes you have a stable spreadsheetID in config.json -
if you don't, it will write a spreadsheetID of the first created document
for you.

This should reduce the number of history entries and allow us to run in automation.
(in theory, we need to test this)