### PR TITLE
Include browser-firefox-tablet in the webcompat-M numbers

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -114,7 +114,7 @@ function getBzLink(dupeSet) {
  */
 function isMobile(bug) {
     const mobileProducts = ['Core', 'Firefox for Android', 'Fenix', 'GeckoView'];
-    const mobileLabels = ['browser-fenix', 'browser-firefox-mobile', 'browser-focus-geckoview', 'browser-geckoview'];
+    const mobileLabels = ['browser-fenix', 'browser-firefox-mobile', 'browser-firefox-tablet', 'browser-focus-geckoview', 'browser-geckoview'];
     const mobileOS = ['Android', 'All', 'Unspecified'];
     return bug.product ?
         ((mobileProducts.includes(bug.product) && mobileOS.includes(bug.op_sys)) ||


### PR DESCRIPTION
I noticed that unlike bugzilla numbers, `webcompat-D + webcompat-M < webcompat`, which seems surprising as both -D and -M include core (shared) bugs. Turns out we don't count tablet bugs in webcompat-M and if we do, at least for google.com where I spot checked, `webcompat-D + webcompat-M >= webcompat` as expected.