### PR TITLE
Fixes #115 - Do a few things to make TSCI run in automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 data
 config.json
 credentials.json
+currentDoc.json
 .vscode/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ would look like:
   "bugzillaKey": "",
   // The GitHub API authentication key.
   "githubKey": "",
+  // The path to save currentDoc.json (by default, CWD)
+  "currentDocPath": ".",
   // A list of domains to ignore when fetching bug results.
   "ignoredDomains": [
     "github.com",
@@ -46,8 +48,9 @@ would look like:
   // The earliest date to consider for when the bug or issue has to have been
   // filed. By default 2018-01-01 is used.
   "minDate": "2018",
-  // The ID of a spreadsheet to append to.
-  "spreadsheetId": null,
+  // The ID of a spreadsheet to work on. This only applies to the first weekly runs,
+  // if more than one week is specified. Otherwise, a new spreadsheet will be created.
+  "startingSpreadsheetId": null,
   // A list of Google accounts with whom the final spreadsheet should be shared.
   "writers": [
     "user@example.com"

--- a/config.json.example
+++ b/config.json.example
@@ -18,7 +18,7 @@
   "ignoreFenix": true,
   "maxDate": null,
   "minDate": "2018",
-  "spreadsheetId": null,
+  "startingSpreadsheetId": null,
   "writers": [
     "user@example.com"
   ]

--- a/config.json.example
+++ b/config.json.example
@@ -3,6 +3,7 @@
   "listDir": "data/",
   "bugzillaKey": "",
   "githubKey": "",
+  "currentDocPath": ".",
   "ignoredDomains": [
     "github.com",
     "github.io",

--- a/helpers.js
+++ b/helpers.js
@@ -220,7 +220,7 @@ function getQueryDates(inputDate) {
  * @param {string} currentDocId
  */
 async function recordCurrentDoc(currentDocId) {
-    return fs.writeFile("currentDoc.json",
+    return fs.writeFile(`${config.currentDocPath}/currentDoc.json`,
         JSON.stringify({"currentDoc": currentDocId}), 'utf8');
 }
 

--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,6 @@
 const config = require('./config.json');
 const fetch = require('node-fetch');
+const fs = require('fs').promises;
 const retry = require('promise-fn-retry');
 const util = require('util');
 
@@ -214,6 +215,16 @@ function getQueryDates(inputDate) {
 }
 
 /**
+ * Write the passed in currentDocId to disk, so it can be read from other
+ * consumers.
+ * @param {string} currentDocId
+ */
+async function recordCurrentDoc(currentDocId) {
+    return fs.writeFile("currentDoc.json",
+        JSON.stringify({"currentDoc": currentDocId}), 'utf8');
+}
+
+/**
  * Return the list of query dates until the present, starting
  * at the specified date.
  * @param {Date} inputDate the date to resume with
@@ -249,5 +260,6 @@ module.exports = {
     isMobile,
     isDesktop,
     isNotQA,
+    recordCurrentDoc,
     resumeQueryDates,
 }

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ const main = async () => {
     const writers = config.writers || ['user@example.com'];
     const maxDate = config.maxDate || undefined;
     const minDate = config.minDate || "2018";
-    let originalId = config.spreadsheetId;
-    let cloneId;
+    let currentDocId = config.startingSpreadsheetId;
+    let oldDocId;
     let queryDates = [];
 
     const parsedMinDate = new Date(minDate);
@@ -45,23 +45,28 @@ const main = async () => {
         const drive = google.drive({ version: 'v3', auth })
 
         const docTitle = 'Top Site Compatibility Index';
-        if (!originalId) {
-            originalId = await spreadsheet.createSpreadsheet(sheets, docTitle, date);
+        if (!currentDocId) {
+            currentDocId = await spreadsheet.createSpreadsheet(sheets, docTitle, date);
         }
-        // Create a clone of the document here so we can operate on that
-        // and only copy over the completed sheet.
-        cloneId = await spreadsheet.cloneDocument(drive, originalId);
-        const { sheetId, title } = await spreadsheet.findOrCreateSheet(sheets, cloneId, date);
-        await spreadsheet.addStaticData(sheets, cloneId, LIST_SIZE, LIST_FILE, sheetId, title);
-        await spreadsheet.addBugData(sheets, cloneId, bugTable, title);
-        await spreadsheet.copySheetToOriginal(sheets, cloneId, originalId);
-        await spreadsheet.updateSummary(sheets, originalId, date);
-        // delete the clone, because we don't need it anymore.
-        await drive.files.delete({fileId: cloneId});
+
+        const { sheetId, title } = await spreadsheet.findOrCreateSheet(sheets, currentDocId, date);
+        await spreadsheet.addStaticData(sheets, currentDocId, LIST_SIZE, LIST_FILE, sheetId, title);
+        await spreadsheet.addBugData(sheets, currentDocId, bugTable, title);
+        await spreadsheet.updateSummary(sheets, currentDocId, date);
+        // now, set the current document to a clone (to become the new current document).
+        // this way have a fresh one to start with next iteration.
+        oldDocId = currentDocId;
+        currentDocId = await spreadsheet.cloneDocument(drive, currentDocId);
+        console.log(`Cloning current document into document with id: ${currentDocId}`);
+        await spreadsheet.updateTitle(sheets, currentDocId);
+
+        // delete the old one, because we don't need it anymore.
+        console.log(`Deleting cloned document with id: ${oldDocId}`);
+        await drive.files.delete({fileId: oldDocId});
 
         for (const writer of writers) {
-            await spreadsheet.shareSheet(drive, originalId, writer);
-            console.log(`► https://docs.google.com/spreadsheets/d/${originalId}/edit`)
+            await spreadsheet.shareSheet(drive, currentDocId, writer);
+            console.log(`Current document ► https://docs.google.com/spreadsheets/d/${currentDocId}/edit`);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -66,8 +66,10 @@ const main = async () => {
 
         for (const writer of writers) {
             await spreadsheet.shareSheet(drive, currentDocId, writer);
-            console.log(`Current document ► https://docs.google.com/spreadsheets/d/${currentDocId}/edit`);
         }
+
+        console.log(`Current document ► https://docs.google.com/spreadsheets/d/${currentDocId}/edit`);
+        await helpers.recordCurrentDoc(currentDocId);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ const main = async () => {
         await spreadsheet.addStaticData(sheets, currentDocId, LIST_SIZE, LIST_FILE, sheetId, title);
         await spreadsheet.addBugData(sheets, currentDocId, bugTable, title);
         await spreadsheet.updateSummary(sheets, currentDocId, date);
+        // Move the newest weekly data sheet to the 4th spot
+        // [ Chart ][ Formula ][ Summary ][ Week N ]([ Week N -1 ]...)
+        await spreadsheet.moveSheet(sheets, currentDocId, date, 3);
         // now, set the current document to a clone (to become the new current document).
         // this way have a fresh one to start with next iteration.
         oldDocId = currentDocId;

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -658,31 +658,16 @@ async function cloneDocument(drive, id) {
 }
 
 /**
- * Copy the last sheet from the cloned document back to the
- * original.
+ * Prevent ending up with "Copy of" in the document title.
  */
-async function copySheetToOriginal(sheets, id, configId) {
-    let resp = await sheets.spreadsheets.get({spreadsheetId: id});
-    const newProperties  = resp.data.sheets[resp.data.sheets.length - 1].properties;
-    // Copy the sheet from our clone to our original sheet
-    await sheets.spreadsheets.sheets.copyTo({
-        spreadsheetId: id,
-        sheetId: newProperties.sheetId,
-        resource: {
-            destinationSpreadsheetId: configId,
-        },
-    });
-    resp = await sheets.spreadsheets.get({spreadsheetId: configId});
-    const origProperties = resp.data.sheets[resp.data.sheets.length - 1].properties;
-    // Update the sheet title (it will be "Copy of $DATE")
+async function updateTitle(sheets, documentId) {
     await sheets.spreadsheets.batchUpdate({
-        spreadsheetId: configId,
+        spreadsheetId: documentId,
         resource: {
             requests: [{
-                "updateSheetProperties": {
+                "updateSpreadsheetProperties": {
                     "properties": {
-                        sheetId: origProperties.sheetId,
-                        title: newProperties.title,
+                        title: "Top Site Compatibility Index",
                     },
                     "fields": "title",
                 },
@@ -695,9 +680,9 @@ module.exports = {
     addBugData,
     addStaticData,
     cloneDocument,
-    copySheetToOriginal,
     createSpreadsheet,
     findOrCreateSheet,
     shareSheet,
     updateSummary,
+    updateTitle,
 }

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -68,6 +68,9 @@ async function createSpreadsheet(sheets, title) {
         },
     });
 
+    await findOrCreateSheet(sheets, spreadsheetId, null, "Chart");
+    await findOrCreateSheet(sheets, spreadsheetId, null, "Formula");
+
     console.log(`Created new spreadsheet with ID: ${spreadsheetId}`);
     return spreadsheetId;
 }

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -71,6 +71,12 @@ async function createSpreadsheet(sheets, title) {
     await findOrCreateSheet(sheets, spreadsheetId, null, "Chart");
     await findOrCreateSheet(sheets, spreadsheetId, null, "Formula");
 
+    // now move the Summary to the 3rd spot.
+    // This makes linking to the Chart simpler, since we don't have to worry
+    // about unpredictable hashes, i.e. #gid=1805032422
+    // [ Chart ][ Formula ][ Summary ][ Week N ]([ Week N -1 ]...)
+    await moveSheet(sheets, spreadsheetId, "Summary", 2);
+
     console.log(`Created new spreadsheet with ID: ${spreadsheetId}`);
     return spreadsheetId;
 }

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -319,12 +319,12 @@ async function addBugData(sheets, spreadsheetId, bugTable, title) {
     console.log('Updated duplicates (Desktop) cells: ' + result.data.updatedCells);
 }
 
-async function findOrCreateSheet(sheets, spreadsheetId, maxDate) {
+async function findOrCreateSheet(sheets, spreadsheetId, maxDate, title) {
     let result = await sheets.spreadsheets.get({
         spreadsheetId,
     });
     // Construct the sheet title.
-    const title = getSheetTitle(maxDate);
+    title = title || getSheetTitle(maxDate);
 
     // Find the sheet to update...
     let sheetId;


### PR DESCRIPTION
Changing the approach a little here:

The idea is to take the "current ID" document (which can be specified as `config.startingSpreadsheetId`), fetch all the data for the current week and put it into that document. Once that's done, we create a clone of that document and store it as the new "current ID". That way we're always operating on a freshly cloned document with no history limits.

We also store the "currentId" in a JSON document on disk so the metrics application can know where to point to (likely just passing in the value to some template method which spits out an iframe in the first iteration).

Note: currently, this will delete *last weeks* copy as soon as a new copy is made. That's mostly just for housekeeping, but it's maybe dangerous until the whole setup with a stable URL exists. (Dangerous to the extent if you had an old URL and re-visited it, it would be missing -- you'll always get a new URL with all the previous data)

A few things left to do:

* [x] it would be nice to have it copy the sheet to the "front", right now we copy things to the end of the sheet list -- it seems nicer to always have the current week after the "Formula" sheet.
* [x] in order for that to happen, we should have the script generate some placeholder sheets for Chart and Formula so the math is more predictable. 
* [x] need to fix the title after each copy to avoid this:

![Screen Shot 2019-10-31 at 1 17 39 PM](https://user-images.githubusercontent.com/67283/67975090-80491f80-fbe1-11e9-9efe-f875ed16982b.png)
