### PR TITLE
Fixes #122 - prevent infinite fetchListID requests (depending on circumstances) 

### DIFF
--- a/tranco.js
+++ b/tranco.js
@@ -71,6 +71,10 @@ const fetchListID = async (date) => {
                 // towards the present.
                 if (date > new Date()) {
                     newDate.setDate(newDate.getDate() - 1);
+                // If we end up at "today", we need to request the list from
+                // the day before -- the daily list is actually a day old.
+                } else if (parseDate(newDate) === parseDate(new Date())) {
+                    newDate.setDate(newDate.getDate() - 2);
                 } else {
                     newDate.setDate(newDate.getDate() + 1);
                 }

--- a/tranco.js
+++ b/tranco.js
@@ -77,13 +77,8 @@ const removeIgnoredDomains = function (listFile) {
  * @returns the String of the list ID
  */
 const fetchListID = async (date) => {
-    const LATEST_LIST_URL = 'https://tranco-list.eu/top-1m-id';
-    let ID_URL = LATEST_LIST_URL;
-    if (date) {
-        ID_URL = `https://tranco-list.eu/daily_list_id?date=${parseDate(date)}`;
-    } else {
-        date = new Date();
-    }
+    const ID_URL = `https://tranco-list.eu/daily_list_id?date=${parseDate(date)}`;
+
     return fetch(ID_URL)
         .then(async res => {
             if (res.ok &&

--- a/tranco.js
+++ b/tranco.js
@@ -87,14 +87,15 @@ const fetchListID = async (date) => {
             }
             else if (res.status === 503) {
                 const newDate = new Date(date);
+                const now = new Date();
                 // Future dates are unlikely to be available yet, but also ones
                 // from long ago may have never been available. Try to converge
                 // towards the present.
-                if (date > new Date()) {
+                if (date > now) {
                     newDate.setDate(newDate.getDate() - 1);
                 // If we end up at "today", we need to request the list from
                 // the day before -- the daily list is actually a day old.
-                } else if (parseDate(newDate) === parseDate(new Date())) {
+                } else if (parseDate(newDate) === parseDate(now)) {
                     newDate.setDate(newDate.getDate() - 2);
                 } else {
                     newDate.setDate(newDate.getDate() + 1);


### PR DESCRIPTION
So, not a daylight savings time issue -- this bug is really about requesting a list that isn't available on tranco (if you request the list for today, it's a 503 because the daily list is actually yesterday's list). Also fixes a bug I found where you can end up requesting the right data but label it in the future. 

### wrong date scenario
current master:

```
npm run start 2019-11-10

> tsci@1.0.0 start /Users/miket/dev/tsci
> GOOGLE_APPLICATION_CREDENTIALS='credentials.json' node index.js "2019-11-10"

Retrying with date Sat Nov 09 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Fri Nov 08 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Thu Nov 07 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Wed Nov 06 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 17:59:59 GMT-0600 (Central Standard Time)
Downloaded Tranco list with ID KWGW for date 2019-11-10
Skipping domains per config.ignoredDomains
```

(note the 2019-11-10 date there).

In this branch
```
npm run start 2019-11-10

> tsci@1.0.0 start /Users/miket/dev/tsci
> GOOGLE_APPLICATION_CREDENTIALS='credentials.json' node index.js "2019-11-10"

Retrying with date Sat Nov 09 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Fri Nov 08 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Thu Nov 07 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Wed Nov 06 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 17:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 17:59:59 GMT-0600 (Central Standard Time)
Downloaded Tranco list with ID KWGW for date 2019-11-04
Skipping domains per config.ignoredDomains
```

### infinite loop scenario

current master

```
npm run start 2019-11-6

> tsci@1.0.0 start /Users/miket/dev/tsci
> GOOGLE_APPLICATION_CREDENTIALS='credentials.json' node index.js "2019-11-6"

Retrying with date Fri Nov 08 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Thu Nov 07 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Wed Nov 06 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
```

this branch:

```
npm run start 2019-11-6

> tsci@1.0.0 start /Users/miket/dev/tsci
> GOOGLE_APPLICATION_CREDENTIALS='credentials.json' node index.js "2019-11-6"

Retrying with date Fri Nov 08 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Thu Nov 07 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Wed Nov 06 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Tue Nov 05 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Mon Nov 04 2019 23:59:59 GMT-0600 (Central Standard Time)
Retrying with date Sat Nov 02 2019 23:59:59 GMT-0500 (Central Daylight Time)
Downloaded Tranco list with ID JLKY for date 2019-11-03
Skipping domains per config.ignoredDomains
```

r? @past 